### PR TITLE
Tune TokenPool contracts to make it compatible with gho-core

### DIFF
--- a/contracts/src/v0.8/ccip/pools/BurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/BurnMintTokenPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.19;
+pragma solidity ^0.8.0;
 
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {IBurnMintERC20} from "../../shared/token/ERC20/IBurnMintERC20.sol";

--- a/contracts/src/v0.8/ccip/pools/BurnMintTokenPoolAbstract.sol
+++ b/contracts/src/v0.8/ccip/pools/BurnMintTokenPoolAbstract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.19;
+pragma solidity ^0.8.0;
 
 import {IBurnMintERC20} from "../../shared/token/ERC20/IBurnMintERC20.sol";
 

--- a/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/LockReleaseTokenPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.19;
+pragma solidity ^0.8.0;
 
 import {ITypeAndVersion} from "../../shared/interfaces/ITypeAndVersion.sol";
 import {ILiquidityContainer} from "../../rebalancer/interfaces/ILiquidityContainer.sol";

--- a/contracts/src/v0.8/ccip/pools/TokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/TokenPool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.19;
+pragma solidity ^0.8.0;
 
 import {IPool} from "../interfaces/pools/IPool.sol";
 import {IARM} from "../interfaces/IARM.sol";
@@ -74,11 +74,11 @@ abstract contract TokenPool is IPool, OwnerIsCreator, IERC165 {
   EnumerableSet.UintSet internal s_remoteChainSelectors;
   /// @dev Outbound rate limits. Corresponds to the inbound rate limit for the pool
   /// on the remote chain.
-  mapping(uint64 remoteChainSelector => RateLimiter.TokenBucket) internal s_outboundRateLimits;
+  mapping(uint64 => RateLimiter.TokenBucket) internal s_outboundRateLimits;
   /// @dev Inbound rate limits. This allows per destination chain
   /// token issuer specified rate limiting (e.g. issuers may trust chains to varying
   /// degrees and prefer different limits)
-  mapping(uint64 remoteChainSelector => RateLimiter.TokenBucket) internal s_inboundRateLimits;
+  mapping(uint64 => RateLimiter.TokenBucket) internal s_inboundRateLimits;
 
   constructor(IERC20 token, address[] memory allowlist, address armProxy, address router) {
     if (address(token) == address(0) || router == address(0)) revert ZeroAddressNotAllowed();

--- a/contracts/src/v0.8/shared/access/ConfirmedOwnerWithProposal.sol
+++ b/contracts/src/v0.8/shared/access/ConfirmedOwnerWithProposal.sol
@@ -45,7 +45,7 @@ contract ConfirmedOwnerWithProposal is IOwnable {
   }
 
   /// @notice validate, transfer ownership, and emit relevant events
-  function _transferOwnership(address to) private {
+  function _transferOwnership(address to) internal {
     // solhint-disable-next-line custom-errors
     require(to != msg.sender, "Cannot transfer to self");
 


### PR DESCRIPTION
Modifications:
- Soften Solidity compiler version of `TokenPool` contracts to `^0.8.0` so they are compatible with [gho-core](https://github.com/aave/gho-core/blob/f02f87482de7ccbd30ba76b40939fb016dbb2fea/foundry.toml#L10).
- Remove named parameters in mapping types (as it was introduced in [v0.8.18](https://github.com/ethereum/solidity/releases/tag/v0.8.18)).
- Makes `_transferOwnership` `internal` instead of `private` so it's possible to initialize the `owner` outside the constructor.