### PR TITLE
test: Update tests to use upgradeable token pools

### DIFF
--- a/contracts/src/v0.8/ccip/test/BaseTest.t.sol
+++ b/contracts/src/v0.8/ccip/test/BaseTest.t.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.19;
 
+import {TransparentUpgradeableProxy} from "solidity-utils/contracts/transparent-proxy/TransparentUpgradeableProxy.sol";
+import {UpgradeableLockReleaseTokenPool} from "../pools/UpgradeableLockReleaseTokenPool.sol";
+import {UpgradeableBurnMintTokenPool} from "../pools/UpgradeableBurnMintTokenPool.sol";
+
 import {Test, stdError} from "forge-std/Test.sol";
 import {MockARM} from "./mocks/MockARM.sol";
 import {StructFactory} from "./StructFactory.sol";
@@ -9,6 +13,9 @@ contract BaseTest is Test, StructFactory {
   bool private s_baseTestInitialized;
 
   MockARM internal s_mockARM;
+
+  address internal PROXY_ADMIN = makeAddr("PROXY_ADMIN");
+  uint256 internal BRIDGE_LIMIT = type(uint128).max;
 
   function setUp() public virtual {
     // BaseTest.setUp is often called multiple times from tests' setUp due to inheritance.
@@ -25,5 +32,84 @@ contract BaseTest is Test, StructFactory {
     vm.warp(BLOCK_TIME);
 
     s_mockARM = new MockARM();
+  }
+
+  function _deployUpgradeableBurnMintTokenPool(
+    address ghoToken,
+    address arm,
+    address router,
+    address owner,
+    address proxyAdmin,
+    address[] memory allowlist
+  ) internal returns (address) {
+    // Deploy BurnMintTokenPool for GHO token on source chain
+    UpgradeableBurnMintTokenPool tokenPoolImpl = new UpgradeableBurnMintTokenPool(ghoToken, arm, allowlist.length > 0);
+    // Imple init
+    tokenPoolImpl.initialize(owner, allowlist, router);
+    // proxy deploy and init
+    bytes memory tokenPoolInitParams = abi.encodeWithSignature(
+      "initialize(address,address[],address)",
+      owner,
+      allowlist,
+      router
+    );
+    TransparentUpgradeableProxy tokenPoolProxy = new TransparentUpgradeableProxy(
+      address(tokenPoolImpl),
+      proxyAdmin,
+      tokenPoolInitParams
+    );
+    // Manage ownership
+    vm.stopPrank();
+    vm.prank(owner);
+    UpgradeableBurnMintTokenPool(address(tokenPoolProxy)).acceptOwnership();
+    vm.startPrank(OWNER);
+
+    return address(tokenPoolProxy);
+  }
+
+  function _deployUpgradeableLockReleaseTokenPool(
+    address ghoToken,
+    address arm,
+    address router,
+    address owner,
+    uint256 bridgeLimit,
+    address proxyAdmin,
+    address[] memory allowlist,
+    bool acceptLiquidity
+  ) internal returns (address) {
+    UpgradeableLockReleaseTokenPool tokenPoolImpl = new UpgradeableLockReleaseTokenPool(
+      ghoToken,
+      arm,
+      allowlist.length > 0,
+      acceptLiquidity
+    );
+    // Imple init
+    tokenPoolImpl.initialize(owner, allowlist, router, bridgeLimit);
+    // proxy deploy and init
+    bytes memory tokenPoolInitParams = abi.encodeWithSignature(
+      "initialize(address,address[],address,uint256)",
+      owner,
+      allowlist,
+      router,
+      bridgeLimit
+    );
+    TransparentUpgradeableProxy tokenPoolProxy = new TransparentUpgradeableProxy(
+      address(tokenPoolImpl),
+      proxyAdmin,
+      tokenPoolInitParams
+    );
+
+    // Manage ownership
+    vm.stopPrank();
+    vm.prank(owner);
+    UpgradeableLockReleaseTokenPool(address(tokenPoolProxy)).acceptOwnership();
+    vm.startPrank(OWNER);
+
+    return address(tokenPoolProxy);
+  }
+
+  function _writeCurrentBridgedAmount(address pool, uint256 newCurrentBridgedAmount) internal {
+    bytes32 CURRENT_BRIDGED_AMOUNT_SLOT = bytes32(uint256(64));
+    vm.store(pool, CURRENT_BRIDGED_AMOUNT_SLOT, bytes32(newCurrentBridgedAmount));
   }
 }

--- a/contracts/src/v0.8/ccip/test/TokenSetup.t.sol
+++ b/contracts/src/v0.8/ccip/test/TokenSetup.t.sol
@@ -36,7 +36,16 @@ contract TokenSetup is RouterSetup {
       s_sourceTokens.push(address(sourceLink));
       s_sourcePools.push(
         address(
-          new LockReleaseTokenPool(sourceLink, new address[](0), address(s_mockARM), true, address(s_sourceRouter))
+          _deployUpgradeableLockReleaseTokenPool({
+            ghoToken: address(sourceLink),
+            arm: address(s_mockARM),
+            router: address(s_sourceRouter),
+            owner: OWNER,
+            bridgeLimit: BRIDGE_LIMIT,
+            proxyAdmin: PROXY_ADMIN,
+            allowlist: new address[](0),
+            acceptLiquidity: true
+          })
         )
       );
 
@@ -44,7 +53,14 @@ contract TokenSetup is RouterSetup {
       deal(address(sourceETH), OWNER, 2 ** 128);
       s_sourceTokens.push(address(sourceETH));
       s_sourcePools.push(
-        address(new BurnMintTokenPool(sourceETH, new address[](0), address(s_mockARM), address(s_sourceRouter)))
+        _deployUpgradeableBurnMintTokenPool({
+          ghoToken: address(sourceETH),
+          arm: address(s_mockARM),
+          router: address(s_sourceRouter),
+          owner: OWNER,
+          proxyAdmin: PROXY_ADMIN,
+          allowlist: new address[](0)
+        })
       );
       sourceETH.grantMintAndBurnRoles(s_sourcePools[1]);
     }
@@ -57,7 +73,16 @@ contract TokenSetup is RouterSetup {
       deal(address(destLink), OWNER, type(uint256).max);
       s_destTokens.push(address(destLink));
       s_destPools.push(
-        address(new LockReleaseTokenPool(destLink, new address[](0), address(s_mockARM), true, address(s_destRouter)))
+        _deployUpgradeableLockReleaseTokenPool({
+          ghoToken: address(destLink),
+          arm: address(s_mockARM),
+          router: address(s_destRouter),
+          owner: OWNER,
+          bridgeLimit: BRIDGE_LIMIT,
+          proxyAdmin: PROXY_ADMIN,
+          allowlist: new address[](0),
+          acceptLiquidity: true
+        })
       );
 
       BurnMintERC677 destEth = new BurnMintERC677("dETH", "dETH", 18, 0);

--- a/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
+++ b/contracts/src/v0.8/ccip/test/e2e/End2End.t.sol
@@ -97,6 +97,10 @@ contract E2E is EVM2EVMOnRampSetup, CommitStoreSetup, EVM2EVMOffRampSetup {
 
     Internal.ExecutionReport memory execReport = _generateReportFromMessages(messages);
     vm.resumeGasMetering();
+
+    // Tweak current bridged amount on destination
+    _writeCurrentBridgedAmount(address(s_destPools[0]), type(uint128).max);
+
     s_offRamp.execute(execReport, new uint256[](0));
   }
 

--- a/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
+++ b/contracts/src/v0.8/ccip/test/onRamp/EVM2EVMOnRamp.t.sol
@@ -719,24 +719,30 @@ contract EVM2EVMOnRamp_getFeeSetup is EVM2EVMOnRampSetup {
     // Add additional pool addresses for test tokens to mark them as supported
     Internal.PoolUpdate[] memory newRamps = new Internal.PoolUpdate[](2);
     address wrappedNativePool = address(
-      new LockReleaseTokenPool(
-        IERC20(s_sourceRouter.getWrappedNative()),
-        new address[](0),
-        address(s_mockARM),
-        true,
-        address(s_sourceRouter)
-      )
+      _deployUpgradeableLockReleaseTokenPool({
+        ghoToken: address(s_sourceRouter.getWrappedNative()),
+        arm: address(s_mockARM),
+        router: address(s_sourceRouter),
+        owner: OWNER,
+        bridgeLimit: BRIDGE_LIMIT,
+        proxyAdmin: PROXY_ADMIN,
+        allowlist: new address[](0),
+        acceptLiquidity: true
+      })
     );
     newRamps[0] = Internal.PoolUpdate({token: s_sourceRouter.getWrappedNative(), pool: wrappedNativePool});
 
     address customPool = address(
-      new LockReleaseTokenPool(
-        IERC20(CUSTOM_TOKEN),
-        new address[](0),
-        address(s_mockARM),
-        true,
-        address(s_sourceRouter)
-      )
+      _deployUpgradeableLockReleaseTokenPool({
+        ghoToken: address(CUSTOM_TOKEN),
+        arm: address(s_mockARM),
+        router: address(s_sourceRouter),
+        owner: OWNER,
+        bridgeLimit: BRIDGE_LIMIT,
+        proxyAdmin: PROXY_ADMIN,
+        allowlist: new address[](0),
+        acceptLiquidity: true
+      })
     );
     newRamps[1] = Internal.PoolUpdate({token: CUSTOM_TOKEN, pool: customPool});
     s_onRamp.applyPoolUpdates(new Internal.PoolUpdate[](0), newRamps);

--- a/contracts/src/v0.8/ccip/test/pools/BurnMintTokenPool.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/BurnMintTokenPool.t.sol
@@ -14,7 +14,16 @@ contract BurnMintTokenPoolSetup is BurnMintSetup {
   function setUp() public virtual override {
     BurnMintSetup.setUp();
 
-    s_pool = new BurnMintTokenPool(s_burnMintERC677, new address[](0), address(s_mockARM), address(s_sourceRouter));
+    s_pool = BurnMintTokenPool(
+      _deployUpgradeableBurnMintTokenPool({
+        ghoToken: address(s_burnMintERC677),
+        arm: address(s_mockARM),
+        router: address(s_sourceRouter),
+        owner: OWNER,
+        proxyAdmin: PROXY_ADMIN,
+        allowlist: new address[](0)
+      })
+    );
     s_burnMintERC677.grantMintAndBurnRoles(address(s_pool));
 
     _applyChainUpdates(address(s_pool));


### PR DESCRIPTION
This code uses GHO custom token pools as TokenPool contracts (instead of standard ones) for all tests.
No need to merge, it is just a way to showcase GHO custom TokenPool contracts are 100% compatible with standard ones.