### PR TITLE
DirectBurn on RemotePool

### DIFF
--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -17,6 +17,7 @@ import {IRouter} from "../../interfaces/IRouter.sol";
 /// - Implementation of Initializable to allow upgrades
 /// - Move of allowlist and router definition to initialization stage
 /// - Inclusion of rate limit admin who may configure rate limits in addition to owner
+/// - Add GHO-Specific onlyOwner `directBurn` which burns liquidity & reduces facilitator level.
 /// - Modifications from inherited contract (see contract for more details):
 ///   - UpgradeableTokenPool: Modify `onlyOnRamp` & `onlyOffRamp` modifier to accept transactions from ProxyPool
 contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintTokenPoolAbstract, ITypeAndVersion {

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -17,7 +17,7 @@ import {IRouter} from "../../interfaces/IRouter.sol";
 /// - Implementation of Initializable to allow upgrades
 /// - Move of allowlist and router definition to initialization stage
 /// - Inclusion of rate limit admin who may configure rate limits in addition to owner
-/// - Add GHO-Specific onlyOwner `directBurn` which burns liquidity & reduces facilitator level.
+/// - Addition of authorized function to to directly burn liquidity, thereby reducing the facilitator's bucket level.
 /// - Modifications from inherited contract (see contract for more details):
 ///   - UpgradeableTokenPool: Modify `onlyOnRamp` & `onlyOffRamp` modifier to accept transactions from ProxyPool
 contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintTokenPoolAbstract, ITypeAndVersion {

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -84,6 +84,18 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
     _setRateLimitConfig(remoteChainSelector, outboundConfig, inboundConfig);
   }
 
+  /// @notice This function allows the owner to burn `amount` of the pool's token. This is
+  /// expected to be called while migrating liquidity to another pool and offboarding this
+  /// facilitator.
+  /// @dev New token pool should mint and transfer liquidity to this pool (since it does not
+  /// hold tokens any point in point, only mints/burns) which can be burnt and hence will reset
+  /// the facilitator bucket level GHO. This is needed to migrate facilitators, by offboarding
+  /// this token pool subsequently.
+  /// @param amount The amount of tokens to burn.
+  function withdrawLiquidity(uint256 amount) external onlyOwner {
+    IBurnMintERC20(address(i_token)).burn(amount);
+  }
+
   /// @inheritdoc UpgradeableBurnMintTokenPoolAbstract
   function _burn(uint256 amount) internal virtual override {
     IBurnMintERC20(address(i_token)).burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -85,12 +85,12 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
   }
 
   /// @notice This function allows the owner to burn `amount` of the pool's token. This is
-  /// expected to be called while migrating liquidity to another pool and offboarding this
-  /// facilitator.
-  /// @dev New token pool should mint and transfer liquidity to this pool (since it does not
-  /// hold tokens any point in point, only mints/burns) which can be burnt and hence will reset
-  /// the facilitator bucket level GHO. This is needed to migrate facilitators, by offboarding
-  /// this token pool subsequently.
+  /// expected to be called while migrating facilitators by offboarding this facilitator in
+  /// favor of a new token pool.
+  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
+  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
+  /// the facilitator bucket level on GHO. The naming convention mimics that in LockRelease
+  /// type token pools for the sake of consistency.
   /// @param amount The amount of tokens to burn.
   function withdrawLiquidity(uint256 amount) external onlyOwner {
     IBurnMintERC20(address(i_token)).burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -89,11 +89,11 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
   /// favor of a new token pool.
   /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
   /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-  /// the facilitator bucket level on GHO. The naming convention mimics that in LockRelease
-  /// type token pools for the sake of consistency.
+  /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
+  /// LockRelease type token pools for the sake of consistency.
   /// @param amount The amount of tokens to burn.
-  function withdrawLiquidity(uint256 amount) external onlyOwner {
-    IBurnMintERC20(address(i_token)).burn(amount);
+  function burnLiquidity(uint256 amount) external onlyOwner {
+    _burn(amount);
   }
 
   /// @inheritdoc UpgradeableBurnMintTokenPoolAbstract

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -92,7 +92,7 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
   /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
   /// LockRelease type token pools for the sake of consistency.
   /// @param amount The amount of tokens to burn.
-  function burnLiquidity(uint256 amount) external onlyOwner {
+  function directBurn(uint256 amount) external onlyOwner {
     _burn(amount);
   }
 

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -90,8 +90,7 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
   /// favor of a new token pool.
   /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
   /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-  /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
-  /// LockRelease type token pools for the sake of consistency.
+  /// the facilitator bucket level on GHO.
   /// @param amount The amount of tokens to burn.
   function directBurn(uint256 amount) external onlyOwner {
     _burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
+++ b/contracts/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
@@ -85,12 +85,11 @@ contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintToken
     _setRateLimitConfig(remoteChainSelector, outboundConfig, inboundConfig);
   }
 
-  /// @notice This function allows the owner to burn `amount` of the pool's token. This is
-  /// expected to be called while migrating facilitators by offboarding this facilitator in
-  /// favor of a new token pool.
-  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
-  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-  /// the facilitator bucket level on GHO.
+  /// @notice Burn an amount of tokens with no additional logic.
+  /// @dev This GHO-specific functionality is designed for migrating bucket levels between
+  /// facilitators. The new pool is expected to mint amount of tokens, while the old pool
+  /// burns an equivalent amount. This ensures the facilitator can be offboarded, as all
+  /// liquidity minted by it must be fully burned
   /// @param amount The amount of tokens to burn.
   function directBurn(uint256 amount) external onlyOwner {
     _burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,6 +1,6 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..3ce2c5a9ab 100644
+index 9af0f22f4c..c35a66e7dc 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
 @@ -1,28 +1,102 @@
@@ -111,11 +111,11 @@ index 9af0f22f4c..3ce2c5a9ab 100644
 +  /// favor of a new token pool.
 +  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
 +  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-+  /// the facilitator bucket level on GHO. The naming convention mimics that in LockRelease
-+  /// type token pools for the sake of consistency.
++  /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
++  /// LockRelease type token pools for the sake of consistency.
 +  /// @param amount The amount of tokens to burn.
-+  function withdrawLiquidity(uint256 amount) external onlyOwner {
-+    IBurnMintERC20(address(i_token)).burn(amount);
++  function burnLiquidity(uint256 amount) external onlyOwner {
++    _burn(amount);
 +  }
 +
 +  /// @inheritdoc UpgradeableBurnMintTokenPoolAbstract

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,9 +1,9 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..b830f7524c 100644
+index 9af0f22f4c..df7c49cb95 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-@@ -1,28 +1,103 @@
+@@ -1,28 +1,102 @@
  // SPDX-License-Identifier: BUSL-1.1
 -pragma solidity 0.8.19;
 +pragma solidity ^0.8.0;
@@ -28,7 +28,7 @@ index 9af0f22f4c..b830f7524c 100644
 +/// - Implementation of Initializable to allow upgrades
 +/// - Move of allowlist and router definition to initialization stage
 +/// - Inclusion of rate limit admin who may configure rate limits in addition to owner
-+/// - Add GHO-Specific onlyOwner `directBurn` which burns liquidity & reduces facilitator level.
++/// - Addition of authorized function to to directly burn liquidity, thereby reducing the facilitator's bucket level.
 +/// - Modifications from inherited contract (see contract for more details):
 +///   - UpgradeableTokenPool: Modify `onlyOnRamp` & `onlyOffRamp` modifier to accept transactions from ProxyPool
 +contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintTokenPoolAbstract, ITypeAndVersion {
@@ -112,8 +112,7 @@ index 9af0f22f4c..b830f7524c 100644
 +  /// favor of a new token pool.
 +  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
 +  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-+  /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
-+  /// LockRelease type token pools for the sake of consistency.
++  /// the facilitator bucket level on GHO.
 +  /// @param amount The amount of tokens to burn.
 +  function directBurn(uint256 amount) external onlyOwner {
 +    _burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,9 +1,9 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..ad4241b2e2 100644
+index 9af0f22f4c..b830f7524c 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-@@ -1,28 +1,102 @@
+@@ -1,28 +1,103 @@
  // SPDX-License-Identifier: BUSL-1.1
 -pragma solidity 0.8.19;
 +pragma solidity ^0.8.0;
@@ -28,6 +28,7 @@ index 9af0f22f4c..ad4241b2e2 100644
 +/// - Implementation of Initializable to allow upgrades
 +/// - Move of allowlist and router definition to initialization stage
 +/// - Inclusion of rate limit admin who may configure rate limits in addition to owner
++/// - Add GHO-Specific onlyOwner `directBurn` which burns liquidity & reduces facilitator level.
 +/// - Modifications from inherited contract (see contract for more details):
 +///   - UpgradeableTokenPool: Modify `onlyOnRamp` & `onlyOffRamp` modifier to accept transactions from ProxyPool
 +contract UpgradeableBurnMintTokenPool is Initializable, UpgradeableBurnMintTokenPoolAbstract, ITypeAndVersion {

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,9 +1,9 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..a5cecc0430 100644
+index 9af0f22f4c..bbd4d018a5 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-@@ -1,28 +1,90 @@
+@@ -1,28 +1,102 @@
  // SPDX-License-Identifier: BUSL-1.1
 -pragma solidity 0.8.19;
 +pragma solidity ^0.8.0;
@@ -104,6 +104,18 @@ index 9af0f22f4c..a5cecc0430 100644
 +    if (msg.sender != s_rateLimitAdmin && msg.sender != owner()) revert Unauthorized(msg.sender);
 +
 +    _setRateLimitConfig(remoteChainSelector, outboundConfig, inboundConfig);
++  }
++
++  /// @notice This function allows the owner to burn `amount` of the pool's token. This is
++  /// expected to be called while migrating liquidity to another pool and offboarding this
++  /// facilitator.
++  /// @dev New token pool should mint and transfer liquidity to this pool (since it does not
++  /// hold tokens any point in point, only mints/burns) which can be burnt and hence will reset
++  /// the facilitator bucket level GHO. This is needed to migrate facilitators, by offboarding
++  /// this token pool subsequently.
++  /// @param amount The amount of tokens to burn.
++  function withdrawLiquidity(uint256 amount) external onlyOwner {
++    IBurnMintERC20(address(i_token)).burn(amount);
 +  }
 +
 +  /// @inheritdoc UpgradeableBurnMintTokenPoolAbstract

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,6 +1,6 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..c35a66e7dc 100644
+index 9af0f22f4c..ad4241b2e2 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
 @@ -1,28 +1,102 @@
@@ -114,7 +114,7 @@ index 9af0f22f4c..c35a66e7dc 100644
 +  /// the facilitator bucket level on GHO. The naming convention is inspired from  that in
 +  /// LockRelease type token pools for the sake of consistency.
 +  /// @param amount The amount of tokens to burn.
-+  function burnLiquidity(uint256 amount) external onlyOwner {
++  function directBurn(uint256 amount) external onlyOwner {
 +    _burn(amount);
 +  }
 +

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,6 +1,6 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..bbd4d018a5 100644
+index 9af0f22f4c..3ce2c5a9ab 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
 @@ -1,28 +1,102 @@
@@ -107,12 +107,12 @@ index 9af0f22f4c..bbd4d018a5 100644
 +  }
 +
 +  /// @notice This function allows the owner to burn `amount` of the pool's token. This is
-+  /// expected to be called while migrating liquidity to another pool and offboarding this
-+  /// facilitator.
-+  /// @dev New token pool should mint and transfer liquidity to this pool (since it does not
-+  /// hold tokens any point in point, only mints/burns) which can be burnt and hence will reset
-+  /// the facilitator bucket level GHO. This is needed to migrate facilitators, by offboarding
-+  /// this token pool subsequently.
++  /// expected to be called while migrating facilitators by offboarding this facilitator in
++  /// favor of a new token pool.
++  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
++  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
++  /// the facilitator bucket level on GHO. The naming convention mimics that in LockRelease
++  /// type token pools for the sake of consistency.
 +  /// @param amount The amount of tokens to burn.
 +  function withdrawLiquidity(uint256 amount) external onlyOwner {
 +    IBurnMintERC20(address(i_token)).burn(amount);

--- a/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
+++ b/contracts/src/v0.8/ccip/pools/GHO/diffs/UpgradeableBurnMintTokenPool_diff.md
@@ -1,9 +1,9 @@
 ```diff
 diff --git a/src/v0.8/ccip/pools/BurnMintTokenPool.sol b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-index 9af0f22f4c..df7c49cb95 100644
+index 9af0f22f4c..f19106fd4d 100644
 --- a/src/v0.8/ccip/pools/BurnMintTokenPool.sol
 +++ b/src/v0.8/ccip/pools/GHO/UpgradeableBurnMintTokenPool.sol
-@@ -1,28 +1,102 @@
+@@ -1,28 +1,101 @@
  // SPDX-License-Identifier: BUSL-1.1
 -pragma solidity 0.8.19;
 +pragma solidity ^0.8.0;
@@ -107,12 +107,11 @@ index 9af0f22f4c..df7c49cb95 100644
 +    _setRateLimitConfig(remoteChainSelector, outboundConfig, inboundConfig);
 +  }
 +
-+  /// @notice This function allows the owner to burn `amount` of the pool's token. This is
-+  /// expected to be called while migrating facilitators by offboarding this facilitator in
-+  /// favor of a new token pool.
-+  /// @dev New token pool should mint and transfer liquidity to this pool (since this pool
-+  /// does not hold tokens at any point in time) which can be burnt and hence will reduce
-+  /// the facilitator bucket level on GHO.
++  /// @notice Burn an amount of tokens with no additional logic.
++  /// @dev This GHO-specific functionality is designed for migrating bucket levels between
++  /// facilitators. The new pool is expected to mint amount of tokens, while the old pool
++  /// burns an equivalent amount. This ensures the facilitator can be offboarded, as all
++  /// liquidity minted by it must be fully burned
 +  /// @param amount The amount of tokens to burn.
 +  function directBurn(uint256 amount) external onlyOwner {
 +    _burn(amount);

--- a/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
@@ -399,21 +399,21 @@ contract GhoTokenPoolRemote_proxyPool is GhoTokenPoolRemoteSetup {
   }
 }
 
-contract GhoTokenPoolRemote_withdrawLiquidity is GhoTokenPoolRemoteSetup {
-  function testWithdrawLiquidityOnlyOwner() public {
+contract GhoTokenPoolRemote_burnLiquidity is GhoTokenPoolRemoteSetup {
+  function testBurnLiquidityOnlyOwner() public {
     vm.startPrank(STRANGER);
     vm.expectRevert("Only callable by owner");
-    s_pool.withdrawLiquidity(13e7);
+    s_pool.burnLiquidity(13e7);
   }
 
-  function testFuzzWithdrawLiquiditySuccess(uint256 amount) public {
+  function testFuzzBurnLiquiditySuccess(uint256 amount) public {
     amount = bound(amount, 1, type(uint128).max); // bound to bucket capacity
     // prank previously bridged supply
     vm.startPrank(address(s_pool));
     s_burnMintERC677.mint(address(s_pool), amount);
 
     vm.startPrank(AAVE_DAO);
-    s_pool.withdrawLiquidity(amount);
+    s_pool.burnLiquidity(amount);
 
     assertEq(s_burnMintERC677.balanceOf(address(s_pool)), 0);
     assertEq(GhoToken(address(s_burnMintERC677)).getFacilitator(address(s_pool)).bucketLevel, 0);

--- a/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
@@ -399,21 +399,21 @@ contract GhoTokenPoolRemote_proxyPool is GhoTokenPoolRemoteSetup {
   }
 }
 
-contract GhoTokenPoolRemote_burnLiquidity is GhoTokenPoolRemoteSetup {
-  function testBurnLiquidityOnlyOwner() public {
+contract GhoTokenPoolRemote_directBurn is GhoTokenPoolRemoteSetup {
+  function testDirectBurnOnlyOwner() public {
     vm.startPrank(STRANGER);
     vm.expectRevert("Only callable by owner");
-    s_pool.burnLiquidity(13e7);
+    s_pool.directBurn(13e7);
   }
 
-  function testFuzzBurnLiquiditySuccess(uint256 amount) public {
+  function testFuzzDirectBurnSuccess(uint256 amount) public {
     amount = bound(amount, 1, type(uint128).max); // bound to bucket capacity
     // prank previously bridged supply
     vm.startPrank(address(s_pool));
     s_burnMintERC677.mint(address(s_pool), amount);
 
     vm.startPrank(AAVE_DAO);
-    s_pool.burnLiquidity(amount);
+    s_pool.directBurn(amount);
 
     assertEq(s_burnMintERC677.balanceOf(address(s_pool)), 0);
     assertEq(GhoToken(address(s_burnMintERC677)).getFacilitator(address(s_pool)).bucketLevel, 0);

--- a/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
@@ -398,3 +398,23 @@ contract GhoTokenPoolRemote_proxyPool is GhoTokenPoolRemoteSetup {
     assertEq(s_pool.getProxyPool(), proxyPool);
   }
 }
+
+contract GhoTokenPoolRemote_withdrawLiquidity is GhoTokenPoolRemoteSetup {
+  function testWithdrawLiquidityOnlyOwner() public {
+    vm.startPrank(STRANGER);
+    vm.expectRevert("Only callable by owner");
+    s_pool.withdrawLiquidity(13e7);
+  }
+
+  function testFuzzWithdrawLiquiditySuccess(uint256 amount) public {
+    amount = bound(amount, 1, type(uint128).max); // bound to bucket capacity
+    // prank newTokenPool.transferLiquidity
+    vm.startPrank(address(s_pool));
+    s_burnMintERC677.mint(address(s_pool), amount);
+
+    vm.startPrank(AAVE_DAO);
+    s_pool.withdrawLiquidity(amount);
+
+    assertEq(s_burnMintERC677.balanceOf(address(s_pool)), 0);
+  }
+}

--- a/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
+++ b/contracts/src/v0.8/ccip/test/pools/GHO/GhoTokenPoolRemote.t.sol
@@ -408,7 +408,7 @@ contract GhoTokenPoolRemote_withdrawLiquidity is GhoTokenPoolRemoteSetup {
 
   function testFuzzWithdrawLiquiditySuccess(uint256 amount) public {
     amount = bound(amount, 1, type(uint128).max); // bound to bucket capacity
-    // prank newTokenPool.transferLiquidity
+    // prank previously bridged supply
     vm.startPrank(address(s_pool));
     s_burnMintERC677.mint(address(s_pool), amount);
 
@@ -416,5 +416,6 @@ contract GhoTokenPoolRemote_withdrawLiquidity is GhoTokenPoolRemoteSetup {
     s_pool.withdrawLiquidity(amount);
 
     assertEq(s_burnMintERC677.balanceOf(address(s_pool)), 0);
+    assertEq(GhoToken(address(s_burnMintERC677)).getFacilitator(address(s_pool)).bucketLevel, 0);
   }
 }


### PR DESCRIPTION
On Remote Token Pool (UpgradeableBurnMintTokenPool):
Adds GHO-Specific onlyOwner `directBurn` which burns liquidity & reduces facilitator level.
Does not add `directMint` since it is being introduced now and the 1.4 tokens are going to be deprecated in favour of 1.5.1 pools (see referenced AIP https://github.com/aave/aave-proposals-v3/pull/19).